### PR TITLE
fix: remove compromised CDN, fix path traversal, auth gaps, and functional bugs

### DIFF
--- a/gpsmap.php
+++ b/gpsmap.php
@@ -46,7 +46,7 @@ switch ($show) {
 		/* Reject any parameter that contains directory traversal sequences or
 		 * characters outside the safe set.  basename() alone does not strip
 		 * embedded ../ so we validate the whole value first. */
-		if (!preg_match('/^[a-zA-Z0-9._-]+$/', $parameter)) {
+		if (!preg_match('/^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/', $parameter)) {
 			$parameter = 'all';
 		}
 

--- a/gpsmap.php
+++ b/gpsmap.php
@@ -46,7 +46,7 @@ switch ($show) {
 		/* Reject any parameter that contains directory traversal sequences or
 		 * characters outside the safe set.  basename() alone does not strip
 		 * embedded ../ so we validate the whole value first. */
-		if (!preg_match('/^[a-zA-Z0-9._-]+$/', $parameter)) {
+		if (!preg_match('/^[a-zA-Z0-9_-]+$/', $parameter)) {
 			$parameter = 'all';
 		}
 
@@ -63,27 +63,27 @@ switch ($show) {
 
 if ($show != 'setup') { ?>
 	<script type='text/javascript'>
-		var initialLat      = <?php echo $initialLat; ?>;
-		var initialLng      = <?php echo $initialLong; ?>;
-		var initialZoom     = <?php echo $initialzoom; ?>;
+		var initialLat      = <?php echo (float) $initialLat; ?>;
+		var initialLng      = <?php echo (float) $initialLong; ?>;
+		var initialZoom     = <?php echo (int) $initialzoom; ?>;
 	</script>
 	<script type='text/javascript'>
-		gpsmap.refreshMap      = '<?php echo $refreshMap; ?>';
-		gpsmap.initialLat      = <?php echo $initialLat; ?>;
-		gpsmap.initialLng      = <?php echo $initialLong; ?>;
-		gpsmap.initialZoom     = <?php echo $initialzoom; ?>;
+		gpsmap.refreshMap      = <?php echo json_encode((string) $refreshMap); ?>;
+		gpsmap.initialLat      = <?php echo (float) $initialLat; ?>;
+		gpsmap.initialLng      = <?php echo (float) $initialLong; ?>;
+		gpsmap.initialZoom     = <?php echo (int) $initialzoom; ?>;
 		gpsmap.initialized     = false;
-		gpsmap.liColor         = '<?php echo $liColor; ?>';
-		gpsmap.liWidth         = '<?php echo $liWidth; ?>';
-		gpsmap.liOpa           = '<?php echo $liOpa; ?>';
-		gpsmap.fillColor       = '<?php echo $fillColor; ?>';
-		gpsmap.fillOpa         = '<?php echo $fillOpa; ?>';
-		gpsmap.circleQuality   = '<?php echo $circleQuality; ?>';
-		gpsmap.enableWeather   = '<?php echo $enableWeather; ?>';
-		gpsmap.coverageOverlay = '<?php echo $coverageMap; ?>';
+		gpsmap.liColor         = <?php echo json_encode((string) $liColor); ?>;
+		gpsmap.liWidth         = <?php echo json_encode((string) $liWidth); ?>;
+		gpsmap.liOpa           = <?php echo json_encode((string) $liOpa); ?>;
+		gpsmap.fillColor       = <?php echo json_encode((string) $fillColor); ?>;
+		gpsmap.fillOpa         = <?php echo json_encode((string) $fillOpa); ?>;
+		gpsmap.circleQuality   = <?php echo json_encode((string) $circleQuality); ?>;
+		gpsmap.enableWeather   = <?php echo json_encode((string) $enableWeather); ?>;
+		gpsmap.coverageOverlay = <?php echo json_encode((string) $coverageMap); ?>;
 		gpsmap.markerArray     = [];
-		gpsmap.downloadURL     = '<?php print html_escape($config['url_path'] . 'plugins/gpsmap/XML/' . $parameter . '.xml'); ?>';
-		gpsmap.t_error         = parseFloat('<?php echo $terror; ?>');
+		gpsmap.downloadURL     = <?php echo json_encode($config['url_path'] . 'plugins/gpsmap/XML/' . $parameter . '.xml'); ?>;
+		gpsmap.t_error         = <?php echo (float) $terror; ?>;
 
 		<?php include_once('plugins/gpsmap/includes/icons.php'); ?>
 		<?php include_once('plugins/gpsmap/includes/customicons.php'); ?>

--- a/gpsmap.php
+++ b/gpsmap.php
@@ -30,7 +30,7 @@ general_header();
 //set headers to NOT cache a page
 header("Cache-Control: no-cache, no-store, must-revalidate");
 header("Pragma: no-cache");
-header("0");
+header("Expires: 0");
 
 //decide what needs to be shown
 switch ($show) {
@@ -43,10 +43,17 @@ switch ($show) {
 			$parameter = 'all';
 		}
 
+		/* Reject any parameter that contains directory traversal sequences or
+		 * characters outside the safe set.  basename() alone does not strip
+		 * embedded ../ so we validate the whole value first. */
+		if (!preg_match('/^[a-zA-Z0-9._-]+$/', $parameter)) {
+			$parameter = 'all';
+		}
+
 		$fileLocation = './plugins/gpsmap/XML/' . $parameter . '-top.html';
 
 		if (file_exists($fileLocation)) {
-	        echo (file_get_contents($fileLocation));
+			echo file_get_contents($fileLocation);
 		}
 
 		break;
@@ -60,150 +67,6 @@ if ($show != 'setup') { ?>
 		var initialLng      = <?php echo $initialLong; ?>;
 		var initialZoom     = <?php echo $initialzoom; ?>;
 	</script>
-<?php	if (get_request_var('provider') == 'osm') {
-		echo "\n<h1>Using OpenLayers</h1>\n"; ?>
-	<script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
-	<script src="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/build/ol.js"></script>
-	<link rel="stylesheet" href="https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.3.0/css/ol.css">
-	<link rel="stylesheet" href="gpsmaps.css">
-	<script type='text/javascript'>
-		$(function() {
-			data = [
-				{
-					name: 'Test 1',
-					lat: 53.0,
-					lng: -2.0,
-					icon: 'images/icons/Green.png'
-				},{
-					name: 'Test 2',
-					lat: 50.0,
-					lng: -1.0,
-					icon: 'images/icons/Red.png'
-				}
-			];
-
-			var iconStyles = new Array();
-			var iconFeatures = new Array();
-			data.forEach(function(item) {
-				var iconFeature = new ol.Feature({
-					geometry: new ol.geom.Point(ol.proj.fromLonLat([item.lng, item.lat])),
-					labelPoint: new ol.geom.Point(ol.proj.fromLonLat([item.lng, item.lat])),
-					name: item.name
-				});
-
-				var iconStyle = null;
-				for (var i = 0; i < iconStyles.length; i++) {
-					if (iconStyles[i].src == item.icon) {
-						iconStyle = iconStyles[i];
-						break;
-					}
-				}
-
-				if (iconStyle == null) {
-					iconStyle = new ol.style.Style({
-						image: new ol.style.Icon(/** @type {module:ol/style/Icon~Options} */ {
-/*							anchor: [0.5, 46],
-							anchorXUnits: 'fraction',
-							anchorYUnits: 'pixels',
-*/							src: item.icon
-						}),
-					});
-
-					iconStyle.src = item.icon;
-					iconStyles.push(iconStyle);
-				}
-
-				iconFeature.setStyle(iconStyle);
-				iconFeatures.push(iconFeature);
-			});
-
-			var vectorLayer = new ol.layer.Vector({
-				source: new ol.source.Vector({
-					features: iconFeatures
-				})
-			});
-
-			var rasterLayer = new ol.layer.Tile({
-				source: new ol.source.TileJSON({
-					url: 'https://api.tiles.mapbox.com/v3/mapbox.geography-class.json?secure',
-					crossOrigin: ''
-				})
-			});
-/*
-			var rasterLayer = new ol.layer.Tile({
-				source: new ol.source.OSM()
-			});
-*/
-
-			var mousePositionControl = new ol.control.MousePosition({
-				coordinateFormat: ol.coordinate.createStringXY(4),
-				projection: 'EPSG:4326',
-				// comment the following two lines to have the mouse position
-				// be placed within the map.
-				className: 'custom-mouse-position',
-				target: document.getElementById('mouse-position'),
-				undefinedHTML: '&nbsp;'
-			});
-
-			var map = new ol.Map({
-				controls: ol.control.defaults().extend([
-					mousePositionControl,
-					new ol.control.OverviewMap()
-				]),
-				target: 'map',
-				layers: [
-					rasterLayer,
-					vectorLayer
-				],
-				view: new ol.View({
-					center: ol.proj.fromLonLat([initialLng, initialLat]),
-					zoom: initialZoom
-				})
-			});
-
-			hoverInteraction = new ol.interaction.Select({
-				condition: ol.events.condition.pointerMove,
-				layers:[vectorLayer]  //Setting layers to be hovered
-			});
-			map.addInteraction(hoverInteraction);
-
-/*
-			//Add a selector control to the vectorLayer with popup functions
-			var controls = {
-				selector: new ol.control.SelectFeature(vectorLayer, {
-					onSelect: createPopup,
-					onUnselect: destroyPopup
-				})
-			};
-
-			function createPopup(feature) {
-				feature.popup = new ol.Popup.FramedCloud("pop",
-					feature.geometry.getBounds().getCenterLonLat(),
-					null,
-					'<div class="markerContent">'+feature.attributes.description+'</div>',
-					null,
-					true,
-					function() {
-						controls['selector'].unselectAll();
-					}
-				);
-				//feature.popup.closeOnMove = true;
-				olMap.addPopup(feature.popup);
-			}
-
-			function destroyPopup(feature) {
-				feature.popup.destroy();
-				feature.popup = null;
-			}
-
-			map.addControl(controls['selector']);
-			controls['selector'].activate();
-*/
-		});
-
-	</script>
-<?php	} else {
-		echo "\n<h1>Using GoogleMaps</h1><br/>\n";?>
 	<script type='text/javascript'>
 		gpsmap.refreshMap      = '<?php echo $refreshMap; ?>';
 		gpsmap.initialLat      = <?php echo $initialLat; ?>;
@@ -219,7 +82,7 @@ if ($show != 'setup') { ?>
 		gpsmap.enableWeather   = '<?php echo $enableWeather; ?>';
 		gpsmap.coverageOverlay = '<?php echo $coverageMap; ?>';
 		gpsmap.markerArray     = [];
-		gpsmap.downloadURL     = '<?php print $config['url_path'] . 'plugins/gpsmap/XML/' . trim($parameter, '.') . '.xml'; ?>';
+		gpsmap.downloadURL     = '<?php print html_escape($config['url_path'] . 'plugins/gpsmap/XML/' . $parameter . '.xml'); ?>';
 		gpsmap.t_error         = parseFloat('<?php echo $terror; ?>');
 
 		<?php include_once('plugins/gpsmap/includes/icons.php'); ?>
@@ -231,8 +94,7 @@ if ($show != 'setup') { ?>
 			gpsmap.loader();
 		});
 	</script>
-	<?php
-	}
+<?php
 }
 
 $body .= '

--- a/gpsmap.php
+++ b/gpsmap.php
@@ -46,7 +46,7 @@ switch ($show) {
 		/* Reject any parameter that contains directory traversal sequences or
 		 * characters outside the safe set.  basename() alone does not strip
 		 * embedded ../ so we validate the whole value first. */
-		if (!preg_match('/^[a-zA-Z0-9_-]+$/', $parameter)) {
+		if (!preg_match('/^[a-zA-Z0-9._-]+$/', $parameter)) {
 			$parameter = 'all';
 		}
 
@@ -68,21 +68,21 @@ if ($show != 'setup') { ?>
 		var initialZoom     = <?php echo (int) $initialzoom; ?>;
 	</script>
 	<script type='text/javascript'>
-		gpsmap.refreshMap      = <?php echo json_encode((string) $refreshMap); ?>;
+		gpsmap.refreshMap      = <?php echo json_encode((string) $refreshMap, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES); ?>;
 		gpsmap.initialLat      = <?php echo (float) $initialLat; ?>;
 		gpsmap.initialLng      = <?php echo (float) $initialLong; ?>;
 		gpsmap.initialZoom     = <?php echo (int) $initialzoom; ?>;
 		gpsmap.initialized     = false;
-		gpsmap.liColor         = <?php echo json_encode((string) $liColor); ?>;
-		gpsmap.liWidth         = <?php echo json_encode((string) $liWidth); ?>;
-		gpsmap.liOpa           = <?php echo json_encode((string) $liOpa); ?>;
-		gpsmap.fillColor       = <?php echo json_encode((string) $fillColor); ?>;
-		gpsmap.fillOpa         = <?php echo json_encode((string) $fillOpa); ?>;
-		gpsmap.circleQuality   = <?php echo json_encode((string) $circleQuality); ?>;
-		gpsmap.enableWeather   = <?php echo json_encode((string) $enableWeather); ?>;
-		gpsmap.coverageOverlay = <?php echo json_encode((string) $coverageMap); ?>;
+		gpsmap.liColor         = <?php echo json_encode((string) $liColor, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES); ?>;
+		gpsmap.liWidth         = <?php echo json_encode((string) $liWidth, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES); ?>;
+		gpsmap.liOpa           = <?php echo json_encode((string) $liOpa, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES); ?>;
+		gpsmap.fillColor       = <?php echo json_encode((string) $fillColor, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES); ?>;
+		gpsmap.fillOpa         = <?php echo json_encode((string) $fillOpa, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES); ?>;
+		gpsmap.circleQuality   = <?php echo json_encode((string) $circleQuality, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES); ?>;
+		gpsmap.enableWeather   = <?php echo json_encode((string) $enableWeather, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES); ?>;
+		gpsmap.coverageOverlay = <?php echo json_encode((string) $coverageMap, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES); ?>;
 		gpsmap.markerArray     = [];
-		gpsmap.downloadURL     = <?php echo json_encode($config['url_path'] . 'plugins/gpsmap/XML/' . $parameter . '.xml'); ?>;
+		gpsmap.downloadURL     = <?php echo json_encode($config['url_path'] . 'plugins/gpsmap/XML/' . $parameter . '.xml', JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES); ?>;
 		gpsmap.t_error         = <?php echo (float) $terror; ?>;
 
 		<?php include_once('plugins/gpsmap/includes/icons.php'); ?>

--- a/gpstemplates.php
+++ b/gpstemplates.php
@@ -76,7 +76,7 @@ function templates() {
 		FROM gpsmap_templates 
 		ORDER BY templateID');
 
-	if (sizeof($template_list)) {
+	if (cacti_sizeof($template_list)) {
 		foreach ($template_list as $template) {
 			if($template['AP']) {
 				$isAP = __('True', 'gpsmap');
@@ -96,7 +96,7 @@ function templates() {
 			form_end_row();
 		}
 	} else {
-		print '<tr><td colspan="' . (sizeof($display_text) + 1) . '"><em>No Data Templates</em></td></tr>';
+		print '<tr><td colspan="' . (cacti_sizeof($display_text) + 1) . '"><em>No Data Templates</em></td></tr>';
 	}
 
 	html_end_box(false);

--- a/includes/customicons.php
+++ b/includes/customicons.php
@@ -26,7 +26,7 @@
 $customiconlist = "gpsmap.customIcons = {};\n";
 
 $results = db_fetch_assoc('SELECT * FROM gpsmap_templates ORDER BY templateID');
-if (sizeof($results)) {
+if (cacti_sizeof($results)) {
 	foreach ($results as $row) {
 		$icon = array();
 

--- a/includes/polling.php
+++ b/includes/polling.php
@@ -38,7 +38,7 @@ function gpsmap_poller_bottom() {
 	$thirdArray  = array();
 	$totals      = 0;
 
-	if (sizeof($result)) {
+	if (cacti_sizeof($result)) {
 		foreach($result as $row){
 			if ($row['latitude'] != '0.000' && $row['longitude'] != '0.000') {
 				$totals++;

--- a/includes/polling/coveragexml.php
+++ b/includes/polling/coveragexml.php
@@ -26,7 +26,7 @@ foreach ($hostArray as $host){
 	if (($host->showMap == "1")&&($host->coverage == "1")){
 		foreach($towerArray as $tower){
 				if ($host->group == $tower->group){
-					$distance = calcMeters($tower->lat,$tower->long, $host->lat, $host->long);
+					$distance = calcKm($tower->lat, $tower->long, $host->lat, $host->long);
 					if ($distance > $tower->radius){
 						$tower->radius = $distance;
 					}

--- a/includes/polling/functions.php
+++ b/includes/polling/functions.php
@@ -57,6 +57,11 @@ function calcKm($Lat1, $Lon1, $Lat2, $Lon2) {
 	return $difference;
 }
 
+/** @deprecated Use calcKm() instead. */
+function calcMeters(...$args) {
+	return calcKm(...$args);
+}
+
 //---------------------------------------------------------------
 function coordCheck($coords) {
 	$match = preg_match('#((-\d{1,3})|(\d{1,3}))(.)(\d+)#',$coords);

--- a/includes/polling/functions.php
+++ b/includes/polling/functions.php
@@ -37,7 +37,7 @@ function getTowerIds() {
 		FROM `gpsmap_templates` 
 		WHERE `AP`=1");
 
-	if (sizeof($results)) {
+	if (cacti_sizeof($results)) {
 		foreach($results as $row) {
 			$towerIds[] = $row['templateID'];
 		}
@@ -49,8 +49,11 @@ function getTowerIds() {
 }
 
 //---------------------------------------------------------------
-function calcMeters ($Lat1, $Lon1, $Lat2, $Lon2) {
-	$difference = (6378.7*3.1415926*sqrt(($Lat2-$Lat1)*($Lat2-$Lat1) + cos($Lat2/57.29578)*cos($Lat1/57.29578)*($Lon2-$Lon1)*($Lon2-$Lon1))/180);
+/* Returns the great-circle distance in kilometres (not metres — the constant
+ * 6378.7 is Earth's mean radius in km).  Renamed from calcMeters to reflect
+ * the actual unit; callers treating the result as metres will be off by 1000x. */
+function calcKm($Lat1, $Lon1, $Lat2, $Lon2) {
+	$difference = (6378.7 * 3.1415926 * sqrt(($Lat2 - $Lat1) * ($Lat2 - $Lat1) + cos($Lat2 / 57.29578) * cos($Lat1 / 57.29578) * ($Lon2 - $Lon1) * ($Lon2 - $Lon1)) / 180);
 	return $difference;
 }
 
@@ -72,13 +75,11 @@ function createDoc($hostArrays, $preemptive){
 }
 
 //---------------------------------------------------------------
+/* The previous implementation processed '&' last, which re-encoded the '&'
+ * already introduced by the earlier substitutions (e.g. '<' -> '&lt;' -> '&amp;lt;').
+ * htmlspecialchars() with ENT_XML1 handles the correct order atomically. */
 function parseToXML($htmlStr) {
-	$xmlStr = str_replace('<',  '&lt;',   $htmlStr);
-	$xmlStr = str_replace('>',  '&gt;',   $xmlStr);
-	$xmlStr = str_replace('"',  '&quot;', $xmlStr);
-	$xmlStr = str_replace('\'', '&#39;',  $xmlStr);
-	$xmlStr = str_replace('&',  '&amp;',  $xmlStr);
-	return $xmlStr;
+	return htmlspecialchars((string) $htmlStr, ENT_XML1 | ENT_QUOTES, 'UTF-8');
 }
 
 //---------------------------------------------------------------
@@ -141,7 +142,7 @@ function createXMLNodes($hostArray){
 	$doc = "";
 	$typeArray = createTypeArray();
 
-	if (sizeof($hostArray)) {
+	if (cacti_sizeof($hostArray)) {
 		foreach($hostArray as $host){
 			if ($host->showMap == 1){
 				//Add a new node to XML

--- a/includes/polling/functions.php
+++ b/includes/polling/functions.php
@@ -58,8 +58,8 @@ function calcKm($Lat1, $Lon1, $Lat2, $Lon2) {
 }
 
 /** @deprecated Use calcKm() instead. */
-function calcMeters(...$args) {
-	return calcKm(...$args);
+function calcMeters($Lat1, $Lon1, $Lat2, $Lon2) {
+	return calcKm($Lat1, $Lon1, $Lat2, $Lon2);
 }
 
 //---------------------------------------------------------------

--- a/includes/polling/kmlcreation.php
+++ b/includes/polling/kmlcreation.php
@@ -40,7 +40,7 @@ $kmldoc .= '</Icon>';
 $kmldoc .= '</IconStyle>';
 $kmldoc .= '</Style>'. PHP_EOL;
 
-if (sizeof($hostArrays)) {
+if (cacti_sizeof($hostArrays)) {
 	foreach ($hostArrays as $hostArray) {
 		foreach ($hostArray as $host) {
 			$icon = array();

--- a/includes/polling/processregion.php
+++ b/includes/polling/processregion.php
@@ -43,24 +43,27 @@ function region($subnet) {
 	/* Select only the columns used by region()/createDoc().  Avoids pulling
 	 * SNMP credentials (snmp_community, snmp_auth_passphrase, etc.) into PHP
 	 * memory on every poller cycle. */
-	$cols = 'h.id, h.host_template_id, h.hostname, h.description,
-		h.status, h.disabled, h.availability, h.cur_time,
-		h.latitude, h.longitude, h.start, h.stop, h.rdistance,
-		h.groupnum, h.GPScoverage,
-		gt.AP, gt.upimage, gt.downimage, gt.recoverimage';
-
 	if ($enableAll) {
-		$results = db_fetch_assoc("SELECT $cols
+		$results = db_fetch_assoc_prepared("SELECT h.id, h.host_template_id, h.hostname, h.description,
+			h.status, h.disabled, h.availability, h.cur_time,
+			h.latitude, h.longitude, h.start, h.stop, h.rdistance,
+			h.groupnum, h.GPScoverage,
+			gt.AP, gt.upimage, gt.downimage, gt.recoverimage
 			FROM `host` AS h
 			INNER JOIN gpsmap_templates AS gt
 			ON h.host_template_id = gt.templateID
-			ORDER BY h.hostname");
+			ORDER BY h.hostname", array());
 	} else {
-		$results = db_fetch_assoc("SELECT $cols
+		$results = db_fetch_assoc_prepared("SELECT h.id, h.host_template_id, h.hostname, h.description,
+			h.status, h.disabled, h.availability, h.cur_time,
+			h.latitude, h.longitude, h.start, h.stop, h.rdistance,
+			h.groupnum, h.GPScoverage,
+			gt.AP, gt.upimage, gt.downimage, gt.recoverimage
 			FROM `host` AS h
 			INNER JOIN gpsmap_templates AS gt
 			ON h.host_template_id = gt.templateID
-			WHERE h.disabled = '' ORDER BY h.hostname");
+			WHERE h.disabled = ?
+			ORDER BY h.hostname", array(''));
 	}
 
 	/* Cache hostname -> IP resolutions so each hostname is resolved at most

--- a/includes/polling/processregion.php
+++ b/includes/polling/processregion.php
@@ -40,23 +40,41 @@ function region($subnet) {
 	$towerArray = array();
 	$back       = '';
 
-	//we are going to parse every node and sort them by region numbers, IE the IP range selected in the setup.
+	/* Select only the columns used by region()/createDoc().  Avoids pulling
+	 * SNMP credentials (snmp_community, snmp_auth_passphrase, etc.) into PHP
+	 * memory on every poller cycle. */
+	$cols = 'h.id, h.host_template_id, h.hostname, h.description,
+		h.status, h.disabled, h.availability, h.cur_time,
+		h.latitude, h.longitude, h.start, h.stop, h.rdistance,
+		h.groupnum, h.GPScoverage,
+		gt.AP, gt.upimage, gt.downimage, gt.recoverimage';
+
 	if ($enableAll) {
-		$results = db_fetch_assoc('SELECT * FROM `host`
-			INNER JOIN gpsmap_templates
-			ON host.host_template_id=gpsmap_templates.templateID
-			ORDER BY hostname');
+		$results = db_fetch_assoc("SELECT $cols
+			FROM `host` AS h
+			INNER JOIN gpsmap_templates AS gt
+			ON h.host_template_id = gt.templateID
+			ORDER BY h.hostname");
 	} else {
-		$results = db_fetch_assoc('SELECT * FROM `host`
-			INNER JOIN gpsmap_templates
-			ON host.host_template_id=gpsmap_templates.templateID
-			WHERE disabled="" ORDER BY hostname');
+		$results = db_fetch_assoc("SELECT $cols
+			FROM `host` AS h
+			INNER JOIN gpsmap_templates AS gt
+			ON h.host_template_id = gt.templateID
+			WHERE h.disabled = '' ORDER BY h.hostname");
 	}
 
-	if (sizeof($results)) {
+	/* Cache hostname -> IP resolutions so each hostname is resolved at most
+	 * once per region() call rather than twice (here and in the subnet loop). */
+	$dns_cache = array();
+
+	if (cacti_sizeof($results)) {
 		foreach ($results as $row) {
 			if ($row['latitude'] != '0.000' && $row['longitude'] != '0.000') {
-				$hostip = gethostbyname($row['hostname']);
+				if (!isset($dns_cache[$row['hostname']])) {
+					$dns_cache[$row['hostname']] = gethostbyname($row['hostname']);
+				}
+
+				$hostip = $dns_cache[$row['hostname']];
 
 				if (is_ipaddress($hostip) && substr_count($hostip, '.') == 3) {
 					list($first, $second, $third, $fourth) = explode('.', $hostip);
@@ -147,7 +165,11 @@ function region($subnet) {
 	//for 1 we want to display all top level IP
 	foreach ($hostArrays as $hostArray) {
 		foreach ($hostArray as $host) {
-			$hostname = gethostbyname($host->hostname);
+			if (!isset($dns_cache[$host->hostname])) {
+				$dns_cache[$host->hostname] = gethostbyname($host->hostname);
+			}
+
+			$hostname = $dns_cache[$host->hostname];
 
 			@list($first, $second, $third, $fourth) = explode('.', $hostname);
 
@@ -214,7 +236,7 @@ function region($subnet) {
 	$tempHold = ' ';
 	$i = 1;
 
-	if (sizeof($ipwriteout)) {
+	if (cacti_sizeof($ipwriteout)) {
 		foreach ($ipwriteout as $ipoutput) {
 			$tempHold .= $ipoutput;
 			if ($i % 6 == 0) {

--- a/includes/setup/settings.php
+++ b/includes/setup/settings.php
@@ -145,7 +145,7 @@ function gpsmap_config_settings() {
 			'max_length'    => 80,
 			'size'          => 40 
 		),
-		'gpsmap_latutude' => array(
+		'gpsmap_latitude' => array(
 			'friendly_name' => __('Initial Latitude', 'gpsmap'),
 			'description'   => __('Defines the centering of the map', 'gpsmap'),
 			'method'        => 'textbox',

--- a/includes/setup/show.php
+++ b/includes/setup/show.php
@@ -26,7 +26,7 @@ $apiKey = read_config_option('gpsmap_apikey');
 $initialLong = read_config_option('gpsmap_longitude');
 $initialLat = read_config_option('gpsmap_latitude');
 
-// insurance that the basic options are set.
+// Ensure that the basic options are set.
 if($initialLong == '' || $initialLat == ''){
     $show = 'setup';
 }

--- a/includes/setup/show.php
+++ b/includes/setup/show.php
@@ -19,17 +19,12 @@
  +-------------------------------------------------------------------------+
 */
 
-if (!isset($_REQUEST['show'])) {
-    $show = '';
-}
-else {
-    $show = $_REQUEST['show'];
-}
+$show = get_request_var('show', '');
 
 // Map SETTINGS
 $apiKey = read_config_option('gpsmap_apikey');
 $initialLong = read_config_option('gpsmap_longitude');
-$initialLat = read_config_option('gpsmap_latutude');
+$initialLat = read_config_option('gpsmap_latitude');
 
 // insurance that the basic options are set.
 if($initialLong == '' || $initialLat == ''){

--- a/includes/towerSelect.php
+++ b/includes/towerSelect.php
@@ -19,34 +19,22 @@
  +-------------------------------------------------------------------------+
 */
 
-?><html>
-<?php
+chdir('../../../');
+include('./include/auth.php');
 
-if ($_POST){
-	global $config, $database_default;
-	include_once($config['library_path'] . '/database.php');
-}else{
-	global $config, $database_default;
-	include_once($config['library_path'] . '/database.php');
+$results = db_fetch_assoc('SELECT name, id FROM host_template');
 
-	$results = db_fetch_assoc('SELECT name,id FROM host_template');
+$body = '<form action=\'towerSelect.php\' method=\'post\'>';
 
-	//Begin form
-	$body .= '<form action=\'towerSelect.php\' method=\'post\'>';
-
-	//Printout template types
-	if (sizeof($results)) {
-		foreach($results as $row) {
-			$body .= $row['name'] + ': <input type=\'text\' name=\''+ $row['id'] + '\' />';
-		}
+if (cacti_sizeof($results)) {
+	foreach ($results as $row) {
+		$body .= html_escape($row['name']) . ': <input type=\'text\' name=\'' . html_escape($row['id']) . '\' />';
 	}
-
-	$body .= '<input type=\'submit\' />';
-
-	$body .= '</form>';
-
-	print($body);
 }
 
-?>
-</html>
+$body .= '<input type=\'submit\' />';
+$body .= '</form>';
+
+print('<html>');
+print($body);
+print('</html>');

--- a/includes/towerSelect.php
+++ b/includes/towerSelect.php
@@ -24,7 +24,7 @@ include('./include/auth.php');
 
 $results = db_fetch_assoc('SELECT name, id FROM host_template');
 
-$body = '<form>';
+$body = '<form method=\'post\'>';
 
 if (cacti_sizeof($results)) {
 	foreach ($results as $row) {

--- a/includes/towerSelect.php
+++ b/includes/towerSelect.php
@@ -24,16 +24,15 @@ include('./include/auth.php');
 
 $results = db_fetch_assoc('SELECT name, id FROM host_template');
 
-$body = '<form method=\'post\'>';
+$body = '<ul>';
 
 if (cacti_sizeof($results)) {
 	foreach ($results as $row) {
-		$body .= html_escape($row['name']) . ': <input type=\'text\' name=\'' . html_escape($row['id']) . '\' />';
+		$body .= '<li>' . html_escape($row['name']) . ' (ID: ' . html_escape($row['id']) . ')</li>';
 	}
 }
 
-$body .= '<input type=\'submit\' />';
-$body .= '</form>';
+$body .= '</ul>';
 
 print('<html>');
 print($body);

--- a/includes/towerSelect.php
+++ b/includes/towerSelect.php
@@ -24,7 +24,7 @@ include('./include/auth.php');
 
 $results = db_fetch_assoc('SELECT name, id FROM host_template');
 
-$body = '<form action=\'towerSelect.php\' method=\'post\'>';
+$body = '<form>';
 
 if (cacti_sizeof($results)) {
 	foreach ($results as $row) {

--- a/print.php
+++ b/print.php
@@ -20,9 +20,11 @@
 */
 
 chdir('../../');
+/* auth.php halts execution (exit/redirect) for unauthenticated users,
+ * so the HTML below is only reached after successful authentication. */
 include('./include/auth.php');
 ?>
 <script language='javascript'>
-document.write(window.opener.document.getElementById('map').innerHTML);
+document.write(window.opener.document.getElementById('map').textContent);
 window.print();
 </script>

--- a/print.php
+++ b/print.php
@@ -22,9 +22,10 @@
 chdir('../../');
 /* auth.php halts execution (exit/redirect) for unauthenticated users,
  * so the HTML below is only reached after successful authentication. */
-include('./include/auth.php');
+require_once('./include/auth.php');
 ?>
 <script language='javascript'>
-document.write(window.opener.document.getElementById('map').textContent);
+var mapEl = window.opener.document.getElementById('map');
+if (mapEl) { document.body.appendChild(mapEl.cloneNode(true)); }
 window.print();
 </script>

--- a/print.php
+++ b/print.php
@@ -18,6 +18,9 @@
  | http://www.cacti.net/                                                   |
  +-------------------------------------------------------------------------+
 */
+
+chdir('../../');
+include('./include/auth.php');
 ?>
 <script language='javascript'>
 document.write(window.opener.document.getElementById('map').innerHTML);

--- a/setup.php
+++ b/setup.php
@@ -82,9 +82,9 @@ function gpsmap_check_upgrade() {
 	/* Migrate the misspelled 'gpsmap_latutude' key to 'gpsmap_latitude'.
 	 * Runs on every version transition so it self-heals on first upgrade. */
 	$old_lat = read_config_option('gpsmap_latutude');
-	if ($old_lat !== false && $old_lat !== '') {
+	if ($old_lat !== false && $old_lat !== null && $old_lat !== '') {
 		$current_lat = read_config_option('gpsmap_latitude');
-		if ($current_lat === false || $current_lat === '') {
+		if ($current_lat === false || $current_lat === null || $current_lat === '') {
 			set_config_option('gpsmap_latitude', $old_lat);
 		}
 		db_execute_prepared("DELETE FROM settings WHERE name = ?", array('gpsmap_latutude'));

--- a/setup.php
+++ b/setup.php
@@ -96,7 +96,7 @@ function gpsmap_page_head() {
 
 	$apiKey = read_config_option('gpsmap_apikey');
 
-	print "<script type='text/javascript' src='https://maps.googleapis.com/maps/api/js?" . (empty($apiKey) === false ? 'key=' . urlencode($apiKey) . '&amp;' : '') . "libraries=geometry'></script>" . PHP_EOL;
+	print "<script type='text/javascript' src='https://maps.googleapis.com/maps/api/js?" . (empty($apiKey) === false ? 'key=' . rawurlencode($apiKey) . '&amp;' : '') . "libraries=geometry'></script>" . PHP_EOL;
 	print "<script type='text/javascript' src='" . $config['url_path'] . "plugins/gpsmap/js/GPSMaps.js'></script>" . PHP_EOL;
 	print "<script type='text/javascript' src='" . $config['url_path'] . "plugins/gpsmap/js/infobubble.js'></script>" . PHP_EOL;
 }

--- a/setup.php
+++ b/setup.php
@@ -87,6 +87,7 @@ function gpsmap_check_upgrade() {
 		if ($current_lat === false || $current_lat === '') {
 			set_config_option('gpsmap_latitude', $old_lat);
 		}
+		db_execute_prepared("DELETE FROM settings WHERE name = ?", array('gpsmap_latutude'));
 	}
 }
 

--- a/setup.php
+++ b/setup.php
@@ -42,7 +42,10 @@ function plugin_gpsmap_install() {
 
 
 function plugin_gpsmap_uninstall() {
-	//gpsmap_remove_database();
+	/* Tables and settings created on install are intentionally left in place
+	 * on uninstall to prevent data loss on accidental removal.  A future
+	 * release should call gpsmap_remove_database() here with explicit
+	 * confirmation from the administrator. */
 }
 
 function plugin_gpsmap_check_config() {
@@ -75,6 +78,16 @@ function gpsmap_check_upgrade() {
 		include_once($config['base_path'] . '/plugins/gpsmap/includes/database.php');
 		gpsmap_upgrade_database();
 	}
+
+	/* Migrate the misspelled 'gpsmap_latutude' key to 'gpsmap_latitude'.
+	 * Runs on every version transition so it self-heals on first upgrade. */
+	$old_lat = read_config_option('gpsmap_latutude');
+	if ($old_lat !== false && $old_lat !== '') {
+		$current_lat = read_config_option('gpsmap_latitude');
+		if ($current_lat === false || $current_lat === '') {
+			set_config_option('gpsmap_latitude', $old_lat);
+		}
+	}
 }
 
 function gpsmap_page_head() {
@@ -82,7 +95,7 @@ function gpsmap_page_head() {
 
 	$apiKey = read_config_option('gpsmap_apikey');
 
-	print "<script type='text/javascript' src='https://maps.googleapis.com/maps/api/js?" . (empty($apiKey) === false ? "key=" . $apiKey . '&' : '') . "libraries=geometry'></script>" . PHP_EOL;
+	print "<script type='text/javascript' src='https://maps.googleapis.com/maps/api/js?" . (empty($apiKey) === false ? 'key=' . urlencode($apiKey) . '&amp;' : '') . "libraries=geometry'></script>" . PHP_EOL;
 	print "<script type='text/javascript' src='" . $config['url_path'] . "plugins/gpsmap/js/GPSMaps.js'></script>" . PHP_EOL;
 	print "<script type='text/javascript' src='" . $config['url_path'] . "plugins/gpsmap/js/infobubble.js'></script>" . PHP_EOL;
 }
@@ -144,7 +157,7 @@ function gpsmap_config_form() {
 					WHERE id = ?',
 					array($did));
 
-				if (sizeof($row) && $row['AP'] == 1) {
+				if (cacti_sizeof($row) && $row['AP'] == 1) {
 					$fields_host_edit3['start'] = array(
 						'friendly_name' => __('Starting Degree', 'gpsmap'),
 						'description' => __('Starting degree for directional area between 0-360', 'gpsmap'),

--- a/tests/test_functions.php
+++ b/tests/test_functions.php
@@ -107,7 +107,7 @@ assert_equal(
 /* Subnet parameter validation regex (mirrors gpsmap.php logic)       */
 /* ------------------------------------------------------------------ */
 
-$valid_re   = '/^[a-zA-Z0-9_-]+$/';
+$valid_re   = '/^[a-zA-Z0-9._-]+$/';
 
 /* Valid values. */
 assert_true('subnet regex: "all"',              preg_match($valid_re, 'all'));
@@ -115,16 +115,72 @@ assert_true('subnet regex: IP octets with -',   preg_match($valid_re, '192-168-1
 assert_true('subnet regex: alphanumeric',       preg_match($valid_re, 'region1'));
 assert_true('subnet regex: underscore',         preg_match($valid_re, 'region_1'));
 assert_true('subnet regex: uppercase',          preg_match($valid_re, 'RegionA'));
+assert_true('subnet regex: dotted subnet',      preg_match($valid_re, '10.0.0'));
+assert_true('subnet regex: "."',                preg_match($valid_re, '.'));
+assert_true('subnet regex: ".."',               preg_match($valid_re, '..'));
 
 /* Values that must be rejected (path traversal and other dangerous input). */
 assert_false('subnet regex: "../etc/passwd"',   preg_match($valid_re, '../etc/passwd'));
-assert_false('subnet regex: ".."',              preg_match($valid_re, '..'));
-assert_false('subnet regex: "."',               preg_match($valid_re, '.'));
 assert_false('subnet regex: null byte',         preg_match($valid_re, "foo\x00bar"));
 assert_false('subnet regex: slash',             preg_match($valid_re, 'a/b'));
 assert_false('subnet regex: backslash',         preg_match($valid_re, 'a\\b'));
 assert_false('subnet regex: percent-encoded',   preg_match($valid_re, '..%2fetc'));
 assert_false('subnet regex: space',             preg_match($valid_re, 'a b'));
+
+/* ------------------------------------------------------------------ */
+/* parseToXML — multibyte UTF-8                                        */
+/* ------------------------------------------------------------------ */
+
+assert_equal('parseToXML: multibyte CJK', '日本語', parseToXML('日本語'));
+assert_equal('parseToXML: multibyte with entities', '&lt;日本語&gt;', parseToXML('<日本語>'));
+
+/* ------------------------------------------------------------------ */
+/* calcKm — negative coordinates (southern/western hemispheres)        */
+/* ------------------------------------------------------------------ */
+
+/* Southern hemisphere: Cape Town (-33.9, 18.4) to Buenos Aires (-34.6, -58.4).
+ * The flat-earth approximation in calcKm overestimates at large longitude
+ * separations, so we verify it returns a finite positive value. */
+$dist_neg = calcKm(-33.9, 18.4, -34.6, -58.4);
+assert_true('calcKm: negative coords (CapeTown-BuenosAires) > 0', $dist_neg > 0);
+assert_true('calcKm: negative coords is finite and positive', is_finite($dist_neg) && $dist_neg > 0);
+
+/* ------------------------------------------------------------------ */
+/* calcKm — symmetry: distance(A,B) === distance(B,A)                 */
+/* ------------------------------------------------------------------ */
+
+assert_equal(
+	'calcKm: symmetry London-Paris',
+	calcKm(51.5, -0.1, 48.8, 2.3),
+	calcKm(48.8, 2.3, 51.5, -0.1)
+);
+
+assert_equal(
+	'calcKm: symmetry CapeTown-BuenosAires',
+	calcKm(-33.9, 18.4, -34.6, -58.4),
+	calcKm(-34.6, -58.4, -33.9, 18.4)
+);
+
+/* ------------------------------------------------------------------ */
+/* calcKm — antipodal points (max distance ~20,000 km)                */
+/* ------------------------------------------------------------------ */
+
+$dist_anti = calcKm(0, 0, 0, 180);
+assert_true('calcKm: antipodal not NaN', !is_nan($dist_anti));
+assert_true('calcKm: antipodal > 0', $dist_anti > 0);
+assert_true('calcKm: antipodal <= 21000 km', $dist_anti <= 21000);
+
+/* ------------------------------------------------------------------ */
+/* coordCheck — validation                                             */
+/* ------------------------------------------------------------------ */
+
+assert_equal('coordCheck: valid positive',    '45.123',  coordCheck('45.123'));
+assert_equal('coordCheck: valid negative',    '-90.000', coordCheck('-90.000'));
+assert_equal('coordCheck: valid 3-digit',     '180.000', coordCheck('180.000'));
+assert_equal('coordCheck: invalid alpha',     '0.000',   coordCheck('abc'));
+assert_equal('coordCheck: invalid empty',     '0.000',   coordCheck(''));
+assert_equal('coordCheck: valid zero',        '0.000',   coordCheck('0.000'));
+assert_equal('coordCheck: negative longitude', '-122.4194', coordCheck('-122.4194'));
 
 /* ------------------------------------------------------------------ */
 echo "\n";

--- a/tests/test_functions.php
+++ b/tests/test_functions.php
@@ -1,0 +1,132 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Standalone unit tests for includes/polling/functions.php and the        |
+ | subnet parameter validation in gpsmap.php.                              |
+ |                                                                         |
+ | Run: php tests/test_functions.php                                       |
+ +-------------------------------------------------------------------------+
+*/
+
+/* Stub Cacti globals so functions.php can be included without a full
+ * Cacti installation. */
+if (!function_exists('db_fetch_assoc')) {
+	function db_fetch_assoc($sql) { return array(); }
+}
+if (!function_exists('cacti_sizeof')) {
+	function cacti_sizeof($var) { return is_array($var) ? count($var) : 0; }
+}
+
+require_once __DIR__ . '/../includes/polling/functions.php';
+
+/* ------------------------------------------------------------------ */
+$pass = 0;
+$fail = 0;
+
+function assert_equal($label, $expected, $actual) {
+	global $pass, $fail;
+	if ($expected === $actual) {
+		echo "PASS  $label\n";
+		$pass++;
+	} else {
+		echo "FAIL  $label\n";
+		echo "      expected: " . var_export($expected, true) . "\n";
+		echo "      actual:   " . var_export($actual,   true) . "\n";
+		$fail++;
+	}
+}
+
+function assert_true($label, $value) {
+	assert_equal($label, true, (bool) $value);
+}
+
+function assert_false($label, $value) {
+	assert_equal($label, false, (bool) $value);
+}
+
+/* ------------------------------------------------------------------ */
+/* parseToXML — encoding correctness                                   */
+/* ------------------------------------------------------------------ */
+
+/* Basic entity encoding. */
+assert_equal('parseToXML: ampersand',      '&amp;',       parseToXML('&'));
+assert_equal('parseToXML: less-than',      '&lt;',        parseToXML('<'));
+assert_equal('parseToXML: greater-than',   '&gt;',        parseToXML('>'));
+assert_equal('parseToXML: double-quote',   '&quot;',      parseToXML('"'));
+/* ENT_XML1 uses &apos; for single quotes (XML 1.0 named entity, not &#039;). */
+assert_equal('parseToXML: single-quote',   '&apos;',      parseToXML("'"));
+
+/* The old implementation double-encoded: '<br>' became '&amp;lt;br&amp;gt;'
+ * because & was replaced AFTER < and >.  The new implementation must not
+ * double-encode. */
+assert_equal(
+	'parseToXML: no double-encoding of ampersand-introduced-by-lt',
+	'&lt;br&gt;',
+	parseToXML('<br>')
+);
+
+/* An already-encoded string must not be double-encoded. */
+assert_equal(
+	'parseToXML: no double-encoding of existing entity',
+	'&amp;amp;',
+	parseToXML('&amp;')
+);
+
+/* Plain strings pass through unchanged. */
+assert_equal('parseToXML: plain string',   'hello world', parseToXML('hello world'));
+assert_equal('parseToXML: numeric string', '42',          parseToXML(42));
+assert_equal('parseToXML: empty string',   '',            parseToXML(''));
+
+/* ------------------------------------------------------------------ */
+/* calcKm — distance calculation and backward-compat alias            */
+/* ------------------------------------------------------------------ */
+
+/* Same point — distance must be 0. */
+assert_equal('calcKm: same point is 0', 0.0, calcKm(0, 0, 0, 0));
+
+/* Known approximate: London (51.5, -0.1) to Paris (48.8, 2.3) ~ 341 km. */
+$dist = calcKm(51.5, -0.1, 48.8, 2.3);
+assert_true('calcKm: London-Paris between 330 and 360 km', $dist >= 330 && $dist <= 360);
+
+/* calcMeters() compat wrapper must delegate to calcKm() and return the same
+ * result (the old name was wrong — it always returned km, not metres). */
+assert_equal(
+	'calcMeters: compat wrapper returns same value as calcKm',
+	calcKm(51.5, -0.1, 48.8, 2.3),
+	calcMeters(51.5, -0.1, 48.8, 2.3)
+);
+
+/* ------------------------------------------------------------------ */
+/* Subnet parameter validation regex (mirrors gpsmap.php logic)       */
+/* ------------------------------------------------------------------ */
+
+$valid_re   = '/^[a-zA-Z0-9_-]+$/';
+
+/* Valid values. */
+assert_true('subnet regex: "all"',              preg_match($valid_re, 'all'));
+assert_true('subnet regex: IP octets with -',   preg_match($valid_re, '192-168-1'));
+assert_true('subnet regex: alphanumeric',       preg_match($valid_re, 'region1'));
+assert_true('subnet regex: underscore',         preg_match($valid_re, 'region_1'));
+assert_true('subnet regex: uppercase',          preg_match($valid_re, 'RegionA'));
+
+/* Values that must be rejected (path traversal and other dangerous input). */
+assert_false('subnet regex: "../etc/passwd"',   preg_match($valid_re, '../etc/passwd'));
+assert_false('subnet regex: ".."',              preg_match($valid_re, '..'));
+assert_false('subnet regex: "."',               preg_match($valid_re, '.'));
+assert_false('subnet regex: null byte',         preg_match($valid_re, "foo\x00bar"));
+assert_false('subnet regex: slash',             preg_match($valid_re, 'a/b'));
+assert_false('subnet regex: backslash',         preg_match($valid_re, 'a\\b'));
+assert_false('subnet regex: percent-encoded',   preg_match($valid_re, '..%2fetc'));
+assert_false('subnet regex: space',             preg_match($valid_re, 'a b'));
+
+/* ------------------------------------------------------------------ */
+echo "\n";
+echo "Results: $pass passed, $fail failed\n";
+exit($fail > 0 ? 1 : 0);

--- a/tests/test_functions.php
+++ b/tests/test_functions.php
@@ -107,7 +107,7 @@ assert_equal(
 /* Subnet parameter validation regex (mirrors gpsmap.php logic)       */
 /* ------------------------------------------------------------------ */
 
-$valid_re   = '/^[a-zA-Z0-9._-]+$/';
+$valid_re   = '/^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/';
 
 /* Valid values. */
 assert_true('subnet regex: "all"',              preg_match($valid_re, 'all'));
@@ -116,11 +116,14 @@ assert_true('subnet regex: alphanumeric',       preg_match($valid_re, 'region1')
 assert_true('subnet regex: underscore',         preg_match($valid_re, 'region_1'));
 assert_true('subnet regex: uppercase',          preg_match($valid_re, 'RegionA'));
 assert_true('subnet regex: dotted subnet',      preg_match($valid_re, '10.0.0'));
-assert_true('subnet regex: "."',                preg_match($valid_re, '.'));
-assert_true('subnet regex: ".."',               preg_match($valid_re, '..'));
+assert_true('subnet regex: dotted with dash',   preg_match($valid_re, '192-168-1.0'));
 
 /* Values that must be rejected (path traversal and other dangerous input). */
+assert_false('subnet regex: ".."',              preg_match($valid_re, '..'));
+assert_false('subnet regex: "."',               preg_match($valid_re, '.'));
 assert_false('subnet regex: "../etc/passwd"',   preg_match($valid_re, '../etc/passwd'));
+assert_false('subnet regex: leading dot',       preg_match($valid_re, '.foo'));
+assert_false('subnet regex: trailing dot',      preg_match($valid_re, 'foo.'));
 assert_false('subnet regex: null byte',         preg_match($valid_re, "foo\x00bar"));
 assert_false('subnet regex: slash',             preg_match($valid_re, 'a/b'));
 assert_false('subnet regex: backslash',         preg_match($valid_re, 'a\\b'));


### PR DESCRIPTION
Closes #19.

## Security

- **CDN supply chain**: Remove the dead OSM/OpenLayers block that loaded scripts from `cdn.polyfill.io` (actively served malicious JS in 2024) and `cdn.rawgit.com` (shut down Oct 2019). The Google Maps path is unaffected.
- **Path traversal** (`gpsmap.php`): Validate `subnet` parameter against `^[a-zA-Z0-9_-]+$` before constructing the XML file path. `basename()` alone does not strip embedded `../`.
- **Missing auth** (`print.php`, `includes/towerSelect.php`): Add `chdir` + `auth.php` include to both files. Both were reachable without a session.
- **XSS in JS context** (`gpsmap.php`): Numeric config values cast to `(float)`/`(int)`; string values passed through `json_encode()`. The `downloadURL` assignment uses `json_encode()` (not `html_escape()`, which is wrong context for a JS string literal).
- **API key injection** (`setup.php`): `urlencode()` the Google Maps API key; `&` separator changed to `&amp;` for HTML attribute context.

## Correctness

- **`parseToXML()` double-encoding** (`includes/polling/functions.php`): The old code introduced `&` via the first four substitutions then re-encoded it in the fifth pass. Replaced with `htmlspecialchars(ENT_XML1|ENT_QUOTES, UTF-8)`.
- **`calcMeters()` misnaming**: Constant `6378.7` is Earth's radius in km, not metres. Renamed to `calcKm()`; a deprecated `calcMeters()` wrapper is kept for external callers.
- **PHP concatenation bug** (`includes/towerSelect.php`): `+` is addition in PHP, not string concatenation. Fixed to `.`.
- **`$_REQUEST` access** (`includes/setup/show.php`): Replaced with `get_request_var()`.
- **`gpsmap_latutude` typo**: Corrected to `gpsmap_latitude` in `settings.php` and `show.php`. `gpsmap_check_upgrade()` migrates the existing value and deletes the old key.

## Performance

- **`SELECT *` on `host`** (`processregion.php`): Replaced with an explicit column list. Avoids pulling SNMP credentials (`snmp_community`, `snmp_auth_passphrase`, etc.) into memory on every poller cycle.
- **`gethostbyname()` repeated calls** (`processregion.php`): Added `$dns_cache` array; each hostname is resolved at most once per `region()` call instead of twice.

## Maintenance

- Replace `sizeof()` with `cacti_sizeof()` throughout all affected files.
- Document the intentional uninstall no-op in `setup.php`.