### PR TITLE
refactor: DRY device-save validation flow

### DIFF
--- a/includes/setup/settings.php
+++ b/includes/setup/settings.php
@@ -70,30 +70,37 @@ function gpsmap_config_arrays() {
    $menu[__('Templates')]['plugins/gpsmap/gpstemplates.php'] = __('Map', 'gpsmap');
 }
 
-function gpsmap_get_validated_device_field(string $request_field, string $validation_field): string {
+function gpsmap_get_validated_device_field(string $request_field, string $validation_field, ?string $missing_validation_field = null): string {
 	$value = '';
+	$field = $validation_field;
 
 	if (isset_request_var($request_field)) {
 		$value = get_nfilter_request_var($request_field);
+	} elseif ($missing_validation_field !== null) {
+		$field = $missing_validation_field;
 	}
 
-	return form_input_validate($value, $validation_field, '', true, 3);
+	return form_input_validate($value, $field, '', true, 3);
 }
 
 function gpsmap_api_device_save($save) {
 	$save['GPScoverage'] = isset_request_var('GPScoverage') ? 'on' : 'off';
 
 	$field_map = [
-		'latitude'  => 'latitude',
-		'longitude' => 'longitude',
-		'start'     => 'start',
-		'stop'      => 'stop',
-		'rdistance' => 'distance',
-		'groupnum'  => 'groupnum',
+		'latitude'  => ['validation' => 'latitude'],
+		'longitude' => ['validation' => 'longitude'],
+		'start'     => ['validation' => 'start'],
+		'stop'      => ['validation' => 'stop'],
+		'rdistance' => ['validation' => 'distance', 'missing_validation' => 'rdistance'],
+		'groupnum'  => ['validation' => 'groupnum'],
 	];
 
-	foreach ($field_map as $field => $validation_field) {
-		$save[$field] = gpsmap_get_validated_device_field($field, $validation_field);
+	foreach ($field_map as $field => $validation) {
+		$save[$field] = gpsmap_get_validated_device_field(
+			$field,
+			$validation['validation'],
+			$validation['missing_validation'] ?? null
+		);
 	}
 
 	return $save;

--- a/includes/setup/settings.php
+++ b/includes/setup/settings.php
@@ -70,50 +70,33 @@ function gpsmap_config_arrays() {
    $menu[__('Templates')]['plugins/gpsmap/gpstemplates.php'] = __('Map', 'gpsmap');
 }
 
+function gpsmap_get_validated_device_field(string $request_field, string $validation_field): string {
+	$value = '';
+
+	if (isset_request_var($request_field)) {
+		$value = get_nfilter_request_var($request_field);
+	}
+
+	return form_input_validate($value, $validation_field, '', true, 3);
+}
+
 function gpsmap_api_device_save($save) {
-	if (isset_request_var('GPScoverage')) {
-		$save['GPScoverage'] = 'on';
-	} else {
-		$save['GPScoverage'] = 'off';
+	$save['GPScoverage'] = isset_request_var('GPScoverage') ? 'on' : 'off';
+
+	$field_map = [
+		'latitude'  => 'latitude',
+		'longitude' => 'longitude',
+		'start'     => 'start',
+		'stop'      => 'stop',
+		'rdistance' => 'distance',
+		'groupnum'  => 'groupnum',
+	];
+
+	foreach ($field_map as $field => $validation_field) {
+		$save[$field] = gpsmap_get_validated_device_field($field, $validation_field);
 	}
 
-    if (isset_request_var('latitude')) {
-        $save['latitude'] = form_input_validate(get_nfilter_request_var('latitude'), 'latitude', '', true, 3);
-	} else {
-        $save['latitude'] = form_input_validate('', 'latitude', '', true, 3);
-	}
-
-    if (isset_request_var('longitude')) {
-        $save['longitude'] = form_input_validate(get_nfilter_request_var('longitude'), 'longitude', '', true, 3);
-	} else {
-        $save['longitude'] = form_input_validate('', 'longitude', '', true, 3);
-	}
-
-    if (isset_request_var('start')) {
-        $save['start'] = form_input_validate(get_nfilter_request_var('start'), 'start', '', true, 3);
-	} else {
-        $save['start'] = form_input_validate('', 'start', '', true, 3);
-	}
-
-    if (isset_request_var('stop')) {
-        $save['stop'] = form_input_validate(get_nfilter_request_var('stop'), 'stop', '', true, 3);
-	} else {
-        $save['stop'] = form_input_validate('', 'stop', '', true, 3);
-	}
-
-    if (isset_request_var('rdistance')) {
-        $save['rdistance'] = form_input_validate(get_nfilter_request_var('rdistance'), 'distance', '', true, 3);
-	} else {
-        $save['rdistance'] = form_input_validate('', 'rdistance', '', true, 3);
-	}
-
-    if (isset_request_var('groupnum')) {
-        $save['groupnum'] = form_input_validate(get_nfilter_request_var('groupnum'), 'groupnum', '', true, 3);
-	} else {
-        $save['groupnum'] = form_input_validate('', 'groupnum', '', true, 3);
-	}
-
-    return $save;
+	return $save;
 }
 
 function gpsmap_config_settings() {
@@ -251,4 +234,3 @@ function gpsmap_config_settings() {
 		)
     );
 }
-

--- a/tests/test_settings_api_device_save.php
+++ b/tests/test_settings_api_device_save.php
@@ -1,0 +1,119 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Standalone regression tests for includes/setup/settings.php             |
+ |                                                                         |
+ | Run: php tests/test_settings_api_device_save.php                        |
+ +-------------------------------------------------------------------------+
+ */
+
+$gpsmap_test_request = [];
+$gpsmap_validate_calls = [];
+
+if (!function_exists('isset_request_var')) {
+	function isset_request_var($name) {
+		global $gpsmap_test_request;
+
+		return array_key_exists($name, $gpsmap_test_request);
+	}
+}
+
+if (!function_exists('get_nfilter_request_var')) {
+	function get_nfilter_request_var($name) {
+		global $gpsmap_test_request;
+
+		return $gpsmap_test_request[$name] ?? '';
+	}
+}
+
+if (!function_exists('form_input_validate')) {
+	function form_input_validate($value, $field, $default = '', $allow_empty = true, $data_type = 3) {
+		global $gpsmap_validate_calls;
+
+		$gpsmap_validate_calls[] = [
+			'value'       => $value,
+			'field'       => $field,
+			'default'     => $default,
+			'allow_empty' => $allow_empty,
+			'data_type'   => $data_type
+		];
+
+		return sprintf('validated:%s:%s', $field, $value);
+	}
+}
+
+require_once __DIR__ . '/../includes/setup/settings.php';
+
+$pass = 0;
+$fail = 0;
+
+function assert_equal($label, $expected, $actual) {
+	global $pass, $fail;
+
+	if ($expected === $actual) {
+		echo "PASS  $label\n";
+		$pass++;
+	} else {
+		echo "FAIL  $label\n";
+		echo '      expected: ' . var_export($expected, true) . "\n";
+		echo '      actual:   ' . var_export($actual, true) . "\n";
+		$fail++;
+	}
+}
+
+/* ------------------------------------------------------------------ */
+/* All fields present                                                   */
+/* ------------------------------------------------------------------ */
+global $gpsmap_test_request, $gpsmap_validate_calls;
+$gpsmap_test_request = [
+	'GPScoverage' => 'on',
+	'latitude'    => '45.1',
+	'longitude'   => '-73.2',
+	'start'       => '1',
+	'stop'        => '10',
+	'rdistance'   => '123.45',
+	'groupnum'    => '3'
+];
+$gpsmap_validate_calls = [];
+
+$save = gpsmap_api_device_save([]);
+
+assert_equal('GPScoverage is enabled when request flag is set', 'on', $save['GPScoverage']);
+assert_equal('latitude validation result', 'validated:latitude:45.1', $save['latitude']);
+assert_equal('longitude validation result', 'validated:longitude:-73.2', $save['longitude']);
+assert_equal('start validation result', 'validated:start:1', $save['start']);
+assert_equal('stop validation result', 'validated:stop:10', $save['stop']);
+assert_equal('rdistance validation result', 'validated:distance:123.45', $save['rdistance']);
+assert_equal('groupnum validation result', 'validated:groupnum:3', $save['groupnum']);
+assert_equal('validation call count with all fields set', 6, count($gpsmap_validate_calls));
+assert_equal('rdistance uses distance validation key', 'distance', $gpsmap_validate_calls[4]['field']);
+
+/* ------------------------------------------------------------------ */
+/* Missing optional request values                                      */
+/* ------------------------------------------------------------------ */
+$gpsmap_test_request = [];
+$gpsmap_validate_calls = [];
+
+$save = gpsmap_api_device_save([]);
+
+assert_equal('GPScoverage is disabled when request flag is missing', 'off', $save['GPScoverage']);
+assert_equal('latitude empty validation result', 'validated:latitude:', $save['latitude']);
+assert_equal('longitude empty validation result', 'validated:longitude:', $save['longitude']);
+assert_equal('start empty validation result', 'validated:start:', $save['start']);
+assert_equal('stop empty validation result', 'validated:stop:', $save['stop']);
+assert_equal('rdistance empty validation result', 'validated:distance:', $save['rdistance']);
+assert_equal('groupnum empty validation result', 'validated:groupnum:', $save['groupnum']);
+assert_equal('validation call count with no fields set', 6, count($gpsmap_validate_calls));
+assert_equal('latitude missing request validates empty string', '', $gpsmap_validate_calls[0]['value']);
+
+echo "\n";
+echo "Results: $pass passed, $fail failed\n";
+
+exit($fail > 0 ? 1 : 0);

--- a/tests/test_settings_api_device_save.php
+++ b/tests/test_settings_api_device_save.php
@@ -108,10 +108,11 @@ assert_equal('latitude empty validation result', 'validated:latitude:', $save['l
 assert_equal('longitude empty validation result', 'validated:longitude:', $save['longitude']);
 assert_equal('start empty validation result', 'validated:start:', $save['start']);
 assert_equal('stop empty validation result', 'validated:stop:', $save['stop']);
-assert_equal('rdistance empty validation result', 'validated:distance:', $save['rdistance']);
+assert_equal('rdistance empty validation result', 'validated:rdistance:', $save['rdistance']);
 assert_equal('groupnum empty validation result', 'validated:groupnum:', $save['groupnum']);
 assert_equal('validation call count with no fields set', 6, count($gpsmap_validate_calls));
 assert_equal('latitude missing request validates empty string', '', $gpsmap_validate_calls[0]['value']);
+assert_equal('rdistance missing request uses legacy rdistance validation key', 'rdistance', $gpsmap_validate_calls[4]['field']);
 
 echo "\n";
 echo "Results: $pass passed, $fail failed\n";


### PR DESCRIPTION
## Summary
- remove repetitive field-by-field request handling in `gpsmap_api_device_save()`
- add `gpsmap_get_validated_device_field()` helper and use a field map + loop
- preserve existing validation behavior while reducing duplicate branches

## Why this is DRY
- collapses six repeated request/validate blocks into one reusable helper path
- keeps validation rules centralized for easier maintenance

## Tests
- `php -l includes/setup/settings.php`
- `php -l tests/test_settings_api_device_save.php`
- `php tests/test_settings_api_device_save.php`
- `php tests/test_functions.php`

Closes #87
