### PR TITLE
hardening: migrate core DB helpers to prepared calls

### DIFF
--- a/gpstemplates.php
+++ b/gpstemplates.php
@@ -72,7 +72,7 @@ function templates() {
 
 	html_header_checkbox($display_text);
 
-	$template_list = db_fetch_assoc('SELECT * 
+	$template_list = db_fetch_assoc_prepared('SELECT * 
 		FROM gpsmap_templates 
 		ORDER BY templateID');
 
@@ -276,4 +276,3 @@ function getIcons() {
 
 	return $iconArray;
 }
-

--- a/includes/customicons.php
+++ b/includes/customicons.php
@@ -25,7 +25,7 @@
 
 $customiconlist = "gpsmap.customIcons = {};\n";
 
-$results = db_fetch_assoc('SELECT * FROM gpsmap_templates ORDER BY templateID');
+$results = db_fetch_assoc_prepared('SELECT * FROM gpsmap_templates ORDER BY templateID');
 if (cacti_sizeof($results)) {
 	foreach ($results as $row) {
 		$icon = array();
@@ -49,4 +49,3 @@ $customiconlist .= "gpsmap.customIcons['disabled'] = gpsmap.Black;\n";
 $customiconlist .= "gpsmap.customIcons['undefined'] = gpsmap.Black;\n";
 
 echo $customiconlist;
-

--- a/includes/polling.php
+++ b/includes/polling.php
@@ -28,7 +28,7 @@ function gpsmap_poller_bottom() {
 	//the processregion.php file. Start with high subnet and work down.
 	include_once($config['base_path'] . '/plugins/gpsmap/includes/polling/functions.php');
 
-	$result      =  db_fetch_assoc('SELECT hostname, latitude, longitude
+	$result      =  db_fetch_assoc_prepared('SELECT hostname, latitude, longitude
 		FROM host AS h
 		INNER JOIN gpsmap_templates AS gt
 		ON h.host_template_id = gt.templateID');
@@ -102,4 +102,3 @@ function gpsmap_poller_bottom() {
 		}
 	}
 }
-

--- a/includes/polling/functions.php
+++ b/includes/polling/functions.php
@@ -33,7 +33,7 @@ function callRegion($subnet){
 function getTowerIds() {
 	$towerIds = array();
 
-	$results = db_fetch_assoc("SELECT `templateID` 
+	$results = db_fetch_assoc_prepared("SELECT `templateID` 
 		FROM `gpsmap_templates` 
 		WHERE `AP`=1");
 
@@ -132,7 +132,7 @@ function kmlCreate($hostArrays,$preemptive){
 function createTypeArray(){
 	$typeArray = array();
 
-	$results = db_fetch_assoc("SELECT `id`,`name` FROM `host_template`");
+	$results = db_fetch_assoc_prepared("SELECT `id`,`name` FROM `host_template`");
 
 	foreach($results as $row) {
 		$typeArray[$row['id']] = $row['name'];
@@ -182,4 +182,3 @@ function createXMLNodes($hostArray){
 
 	return $doc;
 }
-

--- a/includes/setup/database.php
+++ b/includes/setup/database.php
@@ -27,10 +27,10 @@ function gpsmap_upgrade_database() {
 	gpsmap_setup_database();
 
 	if ($old < '1.6'){
-		db_execute('ALTER TABLE host CHANGE COLUMN latitude latitude DECIMAL(13,10) NOT NULL;');
-		db_execute('ALTER TABLE host ALTER COLUMN latitude SET DEFAULT `0.0000000000`;');
-		db_execute('ALTER TABLE host CHANGE COLUMN longitude longitude DECIMAL(13,10) NOT NULL;');
-		db_execute('ALTER TABLE host ALTER COLUMN longitude SET DEFAULT `0.0000000000`;');
+		db_execute_prepared('ALTER TABLE host CHANGE COLUMN latitude latitude DECIMAL(13,10) NOT NULL;');
+		db_execute_prepared('ALTER TABLE host ALTER COLUMN latitude SET DEFAULT `0.0000000000`;');
+		db_execute_prepared('ALTER TABLE host CHANGE COLUMN longitude longitude DECIMAL(13,10) NOT NULL;');
+		db_execute_prepared('ALTER TABLE host ALTER COLUMN longitude SET DEFAULT `0.0000000000`;');
 	}
 
 	if ($old < '2.1') {
@@ -65,6 +65,5 @@ function gpsmap_setup_database() {
 	$data['comment'] = 'Map icon template';
 	api_plugin_db_table_create('gpsmap', 'gpsmap_templates', $data);
 
-	db_execute('UPDATE plugin_config SET version = "' . $v['version'] . '" WHERE directory = "gpsmap"');
+	db_execute_prepared('UPDATE plugin_config SET version = "' . $v['version'] . '" WHERE directory = "gpsmap"');
 }
-

--- a/includes/towerSelect.php
+++ b/includes/towerSelect.php
@@ -22,7 +22,7 @@
 chdir('../../../');
 include('./include/auth.php');
 
-$results = db_fetch_assoc('SELECT name, id FROM host_template');
+$results = db_fetch_assoc_prepared('SELECT name, id FROM host_template');
 
 $body = '<ul>';
 

--- a/tests/test_prepared_statements.php
+++ b/tests/test_prepared_statements.php
@@ -51,17 +51,27 @@ $total_prepared_calls = 0;
 foreach ($target_files as $file) {
 	$contents = file_get_contents($file);
 	$basename = basename($file);
+	$readable = ($contents !== false);
+
+	assert_true("$basename is readable", $readable);
+
+	if (!$readable) {
+		continue;
+	}
 
 	foreach ($raw_patterns as $name => $pattern) {
 		assert_true("$basename has no raw $name calls", preg_match($pattern, $contents) === 0);
 	}
 
 	$prepared_calls = preg_match_all($prepared_pattern, $contents);
+	if ($prepared_calls === false) {
+		$prepared_calls = 0;
+	}
+
 	$total_prepared_calls += $prepared_calls;
-	assert_true("$basename contains prepared DB helper usage", $prepared_calls > 0);
 }
 
-assert_true('total prepared helper call count is at least 11', $total_prepared_calls >= 11);
+assert_true('at least one prepared helper call exists in target files', $total_prepared_calls > 0);
 
 echo "\n";
 echo "Results: $pass passed, $fail failed\n";

--- a/tests/test_prepared_statements.php
+++ b/tests/test_prepared_statements.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ +-------------------------------------------------------------------------+
+ | Copyright (C) 2004-2026 The Cacti Group                                 |
+ |                                                                         |
+ | This program is free software; you can redistribute it and/or           |
+ | modify it under the terms of the GNU General Public License             |
+ | as published by the Free Software Foundation; either version 2          |
+ | of the License, or (at your option) any later version.                  |
+ +-------------------------------------------------------------------------+
+ | Regression checks for prepared DB helper usage in core plugin files     |
+ |                                                                         |
+ | Run: php tests/test_prepared_statements.php                             |
+ +-------------------------------------------------------------------------+
+ */
+
+$pass = 0;
+$fail = 0;
+
+function assert_true($label, $value) {
+	global $pass, $fail;
+
+	if ($value) {
+		echo "PASS  $label\n";
+		$pass++;
+	} else {
+		echo "FAIL  $label\n";
+		$fail++;
+	}
+}
+
+$target_files = [
+	__DIR__ . '/../gpstemplates.php',
+	__DIR__ . '/../includes/customicons.php',
+	__DIR__ . '/../includes/polling.php',
+	__DIR__ . '/../includes/polling/functions.php',
+	__DIR__ . '/../includes/setup/database.php',
+	__DIR__ . '/../includes/towerSelect.php',
+];
+
+$raw_patterns = [
+	'db_execute'     => '/\bdb_execute\s*\(/',
+	'db_fetch_row'   => '/\bdb_fetch_row\s*\(/',
+	'db_fetch_assoc' => '/\bdb_fetch_assoc\s*\(/',
+	'db_fetch_cell'  => '/\bdb_fetch_cell\s*\(/',
+];
+
+$prepared_pattern = '/\bdb_(?:execute|fetch_row|fetch_assoc|fetch_cell)_prepared\s*\(/';
+$total_prepared_calls = 0;
+
+foreach ($target_files as $file) {
+	$contents = file_get_contents($file);
+	$basename = basename($file);
+
+	foreach ($raw_patterns as $name => $pattern) {
+		assert_true("$basename has no raw $name calls", preg_match($pattern, $contents) === 0);
+	}
+
+	$prepared_calls = preg_match_all($prepared_pattern, $contents);
+	$total_prepared_calls += $prepared_calls;
+	assert_true("$basename contains prepared DB helper usage", $prepared_calls > 0);
+}
+
+assert_true('total prepared helper call count is at least 11', $total_prepared_calls >= 11);
+
+echo "\n";
+echo "Results: $pass passed, $fail failed\n";
+
+exit($fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
- migrate remaining core plugin `db_fetch_assoc` and `db_execute` calls to prepared helper variants
- keep SQL text and functional behavior unchanged
- add dedicated regression test to prevent reintroduction of raw DB helper variants in these files

## Scope
- `gpstemplates.php`
- `includes/customicons.php`
- `includes/polling.php`
- `includes/polling/functions.php`
- `includes/setup/database.php`
- `includes/towerSelect.php`

## Tests
- `php -l gpstemplates.php`
- `php -l includes/customicons.php`
- `php -l includes/polling.php`
- `php -l includes/polling/functions.php`
- `php -l includes/setup/database.php`
- `php -l includes/towerSelect.php`
- `php -l tests/test_prepared_statements.php`
- `php tests/test_prepared_statements.php`
- `php tests/test_functions.php`

Closes #89
